### PR TITLE
feature:Add NewUsernameLoginHandler using SingleUsername

### DIFF
--- a/Common/Configuration/ConfigContainer.cs
+++ b/Common/Configuration/ConfigContainer.cs
@@ -90,6 +90,8 @@ public class ServerOption
     public WelcomeMailOption WelcomeMail { get; set; } = new();
     public ServerProfile ServerProfile { get; set; } = new();
     public bool AutoCreateUser { get; set; } = true;
+    public bool SingleUser { get; set; } = true;
+    public string SingleUsername { get; set; } = "player";
     public LogOption LogOption { get; set; } = new();
     public ServerConfig ServerConfig { get; set; } = new();
     public ChallengePeakOption ChallengePeak { get; set; } = new();

--- a/WebServer/Handler/NewUsernameLoginHandler.cs
+++ b/WebServer/Handler/NewUsernameLoginHandler.cs
@@ -11,6 +11,11 @@ public class NewUsernameLoginHandler
     public JsonResult Handle(string account, string password)
     {
         NewLoginResJson res = new();
+
+        if (ConfigManager.Config.ServerOption.SingleUser)
+        {
+            account = ConfigManager.Config.ServerOption.SingleUsername;
+        }
         var accountData = AccountData.GetAccountByUserName(account);
 
         if (accountData == null)


### PR DESCRIPTION
In `/{gameKey}/account/ma-passport/api/appLoginByPassword` and `NewUsernameLoginHandler`,`account` sent by the client changes every time when logging in and is encrypted.
`SingleUser` configuration can avoid creating account and logging into `SingleUsername` `account`.